### PR TITLE
feat: add swReset() to W5100Class to support hardware resets

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,10 +29,11 @@ Michael Margolis   https://github.com/michaelmargolis
 Norbert Truchsess  https://github.com/ntruchsess
 Paul Stoffregen    https://github.com/PaulStoffregen
 per1234            https://github.com/per1234
-Richard Sim
+Richard Sim			
 Scott Fitzgerald   https://github.com/shfitz
 Thibaut Viard      https://github.com/aethaniel
 Tom Igoe           https://github.com/tigoe
 WizNet             http://www.wiznet.co.kr
 Zach Eveland       https://github.com/zeveland
+seagca    https://github.com/seagca
 

--- a/src/utility/w5100.cpp
+++ b/src/utility/w5100.cpp
@@ -58,6 +58,7 @@ uint8_t  W5100Class::ss_pin = SS_PIN_DEFAULT;
 uint16_t W5100Class::SSIZE = 2048;
 uint16_t W5100Class::SMASK = 0x07FF;
 #endif
+static bool initialized = false;
 W5100Class W5100;
 
 // pointers and bitmasks for optimized SS pin
@@ -84,9 +85,14 @@ W5100Class W5100;
 #endif
 
 
+void W5100Class::swReset(void)
+{
+	initialized = false;
+	chip = 0;
+}
+
 uint8_t W5100Class::init(void)
 {
-	static bool initialized = false;
 	uint8_t i;
 
 	if (initialized) return 1;

--- a/src/utility/w5100.h
+++ b/src/utility/w5100.h
@@ -127,6 +127,7 @@ class W5100Class {
 
 public:
   static uint8_t init(void);
+  static void swReset(void);
 
   inline void setGatewayIp(const uint8_t * addr) { writeGAR(addr); }
   inline void getGatewayIp(uint8_t * addr) { readGAR(addr); }


### PR DESCRIPTION
### Description
**What is the issue?**
When making a physical hardware reset by pulling down the `RSTn` pin, the Ethernet library fails to re-assign an IP address. This occurs because `W5100Class::init()` relies on a static local variable `initialized`. Once the chip is initialized the first time, subsequent calls to `init()` return early, so the microcontroller never re-establishes its configuration with the physical chip.

**How does this PR fix it?**
- Moved the `initialized` boolean to file scope in `w5100.cpp`.
- Added a public `swReset()` method to `W5100Class` that resets `initialized = false` and clears the `chip` variable.
- By calling `W5100.swReset()`, developers can now explicitly clear the internal state tracking, allowing `init()` to successfully run again after toggling the RSTn pin. 
- Tested on w6100 and w5100 chips with esp32

**Example usage after this PR:**
```cpp
#include <utility/w5100.h>

// Example: Re-initializing after hard reset
// ... pull RSTn down, then up ...
W5100.swReset(); 
Ethernet.begin(mac, ip); // will now successfully re-configure the chip
